### PR TITLE
Fix Command Compatibility Issues

### DIFF
--- a/AdminTools/Commands/DropItem/DropItem.cs
+++ b/AdminTools/Commands/DropItem/DropItem.cs
@@ -14,7 +14,7 @@ namespace AdminTools.Commands.DropItem
 
         public override string Command { get; } = "dropitem";
 
-        public override string[] Aliases { get; } = new string[] { "drop", "dropi", "di" };
+        public override string[] Aliases { get; } = new string[] { "drop", "dropi" };
 
         public override string Description { get; } = "Drops a specified amount of a specified item on either all users or a user";
 


### PR DESCRIPTION
Both AdminTools, and the Discord Integration plugin use the command `di`, which causes issues when attempting to use both. When a user runs the server it fails to register one of the commands. By removing this alias for the dropitem command, it will solve the problem.
![fcbb9b01103a81d1d4bb0e48f1991702](https://user-images.githubusercontent.com/74625280/110225037-e49b8380-7ea6-11eb-905c-dbe68e30652c.png)
