### PR TITLE
Fix AHP command and compatibility with Discord Integration

### DIFF
--- a/AdminTools/Commands/Ahp/Ahp.cs
+++ b/AdminTools/Commands/Ahp/Ahp.cs
@@ -45,7 +45,7 @@ namespace AdminTools.Commands.Ahp
                     }
 
                     foreach (Player Ply in Player.List)
-                        Ply.AdrenalineHealth = value;
+                        Ply.ArtificialHealth = value;
 
                     response = $"Everyone's AHP was set to {value}";
                     return true;
@@ -63,7 +63,7 @@ namespace AdminTools.Commands.Ahp
                         return false;
                     }
 
-                    Pl.AdrenalineHealth = val;
+                    Pl.ArtificialHealth = val;
                     response = $"Player {Pl.Nickname}'s AHP was set to {val}";
                     return true;
             }

--- a/AdminTools/Commands/DropItem/DropItem.cs
+++ b/AdminTools/Commands/DropItem/DropItem.cs
@@ -14,7 +14,7 @@ namespace AdminTools.Commands.DropItem
 
         public override string Command { get; } = "dropitem";
 
-        public override string[] Aliases { get; } = new string[] { "drop", "dropi", "di" };
+        public override string[] Aliases { get; } = new string[] { "drop", "dropi", "ditem" };
 
         public override string Description { get; } = "Drops a specified amount of a specified item on either all users or a user";
 

--- a/AdminTools/packages.config
+++ b/AdminTools/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EXILED" version="2.1.29" targetFramework="net472" />
+  <package id="EXILED" version="2.8.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Updated to exiled 2.8.0. Fixed AHP and discord integration conflict with `di` command and replaced it with `ditem`