### PR TITLE
Make admin broadcast visible only for AdminChat perms

### DIFF
--- a/AdminTools/Commands/AdminBroadcast/AdminBroadcast.cs
+++ b/AdminTools/Commands/AdminBroadcast/AdminBroadcast.cs
@@ -42,7 +42,7 @@ namespace AdminTools.Commands.AdminBroadcast
 
             foreach (Player Pl in Player.List)
             {
-                if (Pl.ReferenceHub.serverRoles.RemoteAdmin)
+                if (Pl.Sender.CheckPermission(PlayerPermissions.AdminChat))
                     Pl.Broadcast(t, EventHandlers.FormatArguments(arguments, 1) + $" ~{((CommandSender)sender).Nickname}", Broadcast.BroadcastFlags.AdminChat);
             }
 

--- a/AdminTools/Commands/Broadcast/Message.cs
+++ b/AdminTools/Commands/Broadcast/Message.cs
@@ -277,7 +277,7 @@ namespace AdminTools.Commands.Message
 
                     foreach (Player Pl in Player.List)
                     {
-                        if (Pl.ReferenceHub.serverRoles.RemoteAdmin)
+                        if (Pl.Sender.CheckPermission(PlayerPermissions.AdminChat))
                             Pl.Broadcast(t, EventHandlers.FormatArguments(arguments, 2) + $" - {((CommandSender)sender).Nickname}", Broadcast.BroadcastFlags.AdminChat);
                     }
 


### PR DESCRIPTION
Currently, it gets displayed to everyone with RA access which is kind of bad in case you give RA to your donators.

Thanks to Liassid for a better way of doing this