### PR TITLE
add new config options

### DIFF
--- a/AdminTools/Config.cs
+++ b/AdminTools/Config.cs
@@ -10,5 +10,11 @@ namespace AdminTools
         public bool IsEnabled { get; set; } = true;
         [Description("Should the tutorial class be in God Mode? Default: true")]
         public bool GodTuts { get; set; } = true;
+        [Description("Should the tutorial class be in ignored by Tesla Gates? Default: true")]
+        public bool IgnoreTuts { get; set; } = true;
+        [Description("Enable/Disable Auto Overwatch.")]
+        public bool AutoOverwatch { get; set; } = true;
+        [Description("Enable/Disable Auto Hidetag.")]
+        public bool AutoHidetag { get; set; } = true;
     }
 }


### PR DESCRIPTION
- Added `AutoOverwatch` config option to toggle if players in overwatch mode should be saved across rounds
- Added `AutoHidetag` config option to toggle if players that have their tag hidden should be saved across rounds
- Added `IgnoreTuts` config option to toggle if Tesla Gates ignore players in Tutorial

Incase you are wondering why, I mainly made this change because AutoOverwatch was interfering with the Lobby System I made to abide with new Official Server Rules regarding player limit and reserved slots.
I also saw no harm in adding a few more that some people mind find useful, incase AT was adding something they weren't explicitly wanting (e.g Tesla Gates ignoring Tutorials)