### PR TITLE
Keep PlayerEffects after unjailing

### DIFF
--- a/AdminTools/Config.cs
+++ b/AdminTools/Config.cs
@@ -10,5 +10,11 @@ namespace AdminTools
         public bool IsEnabled { get; set; } = true;
         [Description("Should the tutorial class be in God Mode? Default: true")]
         public bool GodTuts { get; set; } = true;
+        [Description("Should the tutorial class be in ignored by Tesla Gates? Default: true")]
+        public bool IgnoreTuts { get; set; } = true;
+        [Description("Enable/Disable Auto Overwatch.")]
+        public bool AutoOverwatch { get; set; } = true;
+        [Description("Enable/Disable Auto Hidetag.")]
+        public bool AutoHidetag { get; set; } = true;
     }
 }

--- a/AdminTools/EventHandlers.cs
+++ b/AdminTools/EventHandlers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using CustomPlayerEffects;
 using Exiled.API.Enums;
 using Exiled.API.Features;
 using Exiled.Events.EventArgs;
@@ -252,6 +253,7 @@ namespace AdminTools
 			{
 				Plugin.JailedPlayers.Add(new Jailed
 				{
+					Effects = player.ActiveEffects,
 					Health = player.Health,
 					Position = player.Position,
 					Items = items,
@@ -283,6 +285,8 @@ namespace AdminTools
 				player.Position = jail.Position;
 				foreach (KeyValuePair<AmmoType, ushort> kvp in jail.Ammo)
 					player.Ammo[kvp.Key.GetItemType()] = kvp.Value;
+				foreach (PlayerEffect effect in jail.Effects)
+					player.EnableEffect(effect);
 			}
 			else
 			{

--- a/AdminTools/Jailed.cs
+++ b/AdminTools/Jailed.cs
@@ -1,5 +1,6 @@
 using Exiled.API.Enums;
 using System.Collections.Generic;
+using CustomPlayerEffects;
 using UnityEngine;
 
 namespace AdminTools
@@ -16,5 +17,6 @@ namespace AdminTools
 		public float Health;
 		public Dictionary<AmmoType, ushort> Ammo;
 		public bool CurrentRound;
+		public IEnumerable<PlayerEffect> Effects;
 	}
 }


### PR DESCRIPTION
- Added `AutoOverwatch` config option to toggle if players in overwatch mode should be saved across rounds
- Added `AutoHidetag` config option to toggle if players that have their tag hidden should be saved across rounds
- Added `IgnoreTuts` config option to toggle if Tesla Gates ignore players in Tutorial

- Players keep their `PlayerEffects` after getting unjailed

Incase you are wondering why, I mainly made this change because AutoOverwatch was interfering with the Lobby System I made to abide with new Official Server Rules regarding player limit and reserved slots.
I also saw no harm in adding a few more that some people mind find useful, incase AT was adding something they weren't explicitly wanting (e.g Tesla Gates ignoring Tutorials)