### PR TITLE
Add config options and keep PlayerEffects after unjailing

### DIFF
--- a/AdminTools/Config.cs
+++ b/AdminTools/Config.cs
@@ -10,8 +10,6 @@ namespace AdminTools
         public bool IsEnabled { get; set; } = true;
         [Description("Should the tutorial class be in God Mode? Default: true")]
         public bool GodTuts { get; set; } = true;
-        [Description("Should players in godmode be ignored by Tesla Gates? Default: true")]
-        public bool TeslasIgnoreGods { get; set; } = true;
         [Description("Enable/Disable Auto Overwatch. Default: true")]
         public bool AutoOverwatch { get; set; } = true;
         [Description("Enable/Disable Auto Hidetag. Default: true")]

--- a/AdminTools/Config.cs
+++ b/AdminTools/Config.cs
@@ -10,5 +10,11 @@ namespace AdminTools
         public bool IsEnabled { get; set; } = true;
         [Description("Should the tutorial class be in God Mode? Default: true")]
         public bool GodTuts { get; set; } = true;
+        [Description("Should players in godmode be ignored by Tesla Gates? Default: true")]
+        public bool TeslasIgnoreGods { get; set; } = true;
+        [Description("Enable/Disable Auto Overwatch. Default: true")]
+        public bool AutoOverwatch { get; set; } = true;
+        [Description("Enable/Disable Auto Hidetag. Default: true")]
+        public bool AutoHidetag { get; set; } = true;
     }
 }

--- a/AdminTools/EventHandlers.cs
+++ b/AdminTools/EventHandlers.cs
@@ -26,7 +26,6 @@ namespace AdminTools
 	using InventorySystem.Items.ThrowableProjectiles;
 	using PlayerStatsSystem;
 	using Ragdoll = Exiled.API.Features.Ragdoll;
-	using CustomPlayerEffects;
 
 	public class EventHandlers
 	{
@@ -257,8 +256,7 @@ namespace AdminTools
 					Role = player.Role,
 					Userid = player.UserId,
 					CurrentRound = true,
-					Ammo = ammo,
-					Effects = player.ActiveEffects
+					Ammo = ammo
 				});
 			}
 
@@ -282,8 +280,6 @@ namespace AdminTools
 				player.Position = jail.Position;
 				foreach (KeyValuePair<AmmoType, ushort> kvp in jail.Ammo)
 					player.Ammo[kvp.Key.GetItemType()] = kvp.Value;
-				foreach (PlayerEffect effect in jail.Effects)
-					player.EnableEffect(effect);
 			}
 			else
 			{

--- a/AdminTools/EventHandlers.cs
+++ b/AdminTools/EventHandlers.cs
@@ -402,7 +402,7 @@ namespace AdminTools
 
 		public void OnTriggerTesla(TriggeringTeslaEventArgs ev)
 		{
-			if (ev.Player.IsGodModeEnabled && _plugin.Config.TeslasIgnoreGods)
+			if (ev.Player.IsGodModeEnabled)
 			{
 				ev.IsInIdleRange = false;
 				ev.IsTriggerable = false;

--- a/AdminTools/Jailed.cs
+++ b/AdminTools/Jailed.cs
@@ -1,6 +1,7 @@
 using Exiled.API.Enums;
 using System.Collections.Generic;
 using UnityEngine;
+using CustomPlayerEffects;
 
 namespace AdminTools
 {
@@ -16,5 +17,6 @@ namespace AdminTools
 		public float Health;
 		public Dictionary<AmmoType, ushort> Ammo;
 		public bool CurrentRound;
+		public IEnumerable<PlayerEffect> Effects;
 	}
 }

--- a/AdminTools/Jailed.cs
+++ b/AdminTools/Jailed.cs
@@ -1,7 +1,6 @@
 using Exiled.API.Enums;
 using System.Collections.Generic;
 using UnityEngine;
-using CustomPlayerEffects;
 
 namespace AdminTools
 {
@@ -17,6 +16,5 @@ namespace AdminTools
 		public float Health;
 		public Dictionary<AmmoType, ushort> Ammo;
 		public bool CurrentRound;
-		public IEnumerable<PlayerEffect> Effects;
 	}
 }


### PR DESCRIPTION
- Added `AutoOverwatch` config option to toggle if players in overwatch mode should be saved across rounds
- Added `AutoHidetag` config option to toggle if players that have their tag hidden should be saved across rounds


- ~~Players keep their `PlayerEffects` after getting unjailed~~ Unable to test this, and rather not merge a broken feature
- Teslas no longer enter Idle mode when a player in godmode approaches - thanks to @louis1706 for reminding me