### PR TITLE
Unjail all players on restart

### DIFF
--- a/AdminTools/Config.cs
+++ b/AdminTools/Config.cs
@@ -10,5 +10,7 @@ namespace AdminTools
         public bool IsEnabled { get; set; } = true;
         [Description("Should the tutorial class be in God Mode? Default: true")]
         public bool GodTuts { get; set; } = true;
+        [Description("Unjails all jailed players automatically when the round restarts.")]
+        public bool ClearJailsOnRestart { get; set; } = false;
     }
 }

--- a/AdminTools/Config.cs
+++ b/AdminTools/Config.cs
@@ -10,7 +10,7 @@ namespace AdminTools
         public bool IsEnabled { get; set; } = true;
         [Description("Should the tutorial class be in God Mode? Default: true")]
         public bool GodTuts { get; set; } = true;
-        [Description("Unjail all jailed players automatically when the round restarts?")]
+        [Description("Unjail all jailed players automatically when the round restarts? Default: false")]
         public bool ClearJailsOnRestart { get; set; } = false;
     }
 }

--- a/AdminTools/Config.cs
+++ b/AdminTools/Config.cs
@@ -10,7 +10,7 @@ namespace AdminTools
         public bool IsEnabled { get; set; } = true;
         [Description("Should the tutorial class be in God Mode? Default: true")]
         public bool GodTuts { get; set; } = true;
-        [Description("Unjails all jailed players automatically when the round restarts.")]
+        [Description("Unjail all jailed players automatically when the round restarts?")]
         public bool ClearJailsOnRestart { get; set; } = false;
     }
 }

--- a/AdminTools/EventHandlers.cs
+++ b/AdminTools/EventHandlers.cs
@@ -347,6 +347,9 @@ namespace AdminTools
 				File.WriteAllLines(_plugin.OverwatchFilePath, overwatchRead);
 				File.WriteAllLines(_plugin.HiddenTagsFilePath, tagsRead);
 
+				if (_plugin.Config.ClearJailsOnRestart)
+					Plugin.JailedPlayers.Clear();
+
 				// Update all the jails that it is no longer the current round, so when they are unjailed they don't teleport into the void.
 				foreach (Jailed jail in Plugin.JailedPlayers)
 				{


### PR DESCRIPTION
Adds a config to unjail all players when the round restarts. Requested by server I'm an admin of, since persistent jailing causes problems with players being stuck jailed while everyone is playing. I'm sure other servers could use it too.