### PR TITLE
Changes the behavior of GodTuts

### DIFF
--- a/AdminTools/EventHandlers.cs
+++ b/AdminTools/EventHandlers.cs
@@ -11,6 +11,8 @@ namespace AdminTools
     using Log = Exiled.API.Features.Log;
     using PlayerStatsSystem;
     using Handlers = Exiled.Events.Handlers;
+    using Exiled.API.Enums;
+    using Exiled.Events.Commands.Reload;
 
     public class EventHandlers
 	{
@@ -28,9 +30,7 @@ namespace AdminTools
 			Handlers.Server.RoundStarted += OnRoundStarted;
 			Handlers.Player.Destroying += OnPlayerDestroying;
 			Handlers.Player.InteractingDoor += OnPlayerInteractingDoor;
-			
-			if (plugin.Config.GodTuts)
-				Handlers.Player.ChangingRole += OnChangingRole;
+			Handlers.Player.ChangingRole += OnChangingRole;
 		}
 
 		~EventHandlers()
@@ -44,7 +44,8 @@ namespace AdminTools
 			Handlers.Server.RoundStarted -= OnRoundStarted;
 			Handlers.Player.Destroying -= OnPlayerDestroying;
 			Handlers.Player.InteractingDoor -= OnPlayerInteractingDoor;
-		}
+            Handlers.Player.ChangingRole -= OnChangingRole;
+        }
 
 		public void OnInteractingDoor(InteractingDoorEventArgs ev)
 		{
@@ -127,7 +128,11 @@ namespace AdminTools
 				ev.IsAllowed = false;
 		}
 
-		public void OnChangingRole(ChangingRoleEventArgs ev) => ev.Player.IsGodModeEnabled = ev.NewRole is RoleTypeId.Tutorial;
+		public void OnChangingRole(ChangingRoleEventArgs ev)
+        {
+            if (plugin.Config.GodTuts && ev.Player.RemoteAdminAccess && ev.Reason == SpawnReason.ForceClass)
+                ev.Player.IsGodModeEnabled = ev.NewRole == RoleTypeId.Tutorial;
+        }
 
         public void OnWaitingForPlayers()
 		{


### PR DESCRIPTION
GodTuts to only apply if a player is forceclassed and has RA perms, makes it so that the Tutorial role is available as a custom role (Should work for staff members as well, if other plugins spawn tutorials with proper flags!)

SpawnRagdoll now supports names and death reasons of custom word length, so long as those arguments are "quoted" If the arguments are not quoted, it will work as long as arguments are equal to 5.