### PR TITLE
Changes GodTuts

### DIFF
--- a/AdminTools/Config.cs
+++ b/AdminTools/Config.cs
@@ -11,7 +11,7 @@ namespace AdminTools
         [Description("Whether or not to show logs used for debugging.")]
         public bool Debug { get; set; } = false;
 
-        [Description("Should the tutorial class be in God Mode? Default: false")]
+        [Description("Should Staff be in God Mode when they forceclass to Tutorial?? Default: false")]
         public bool GodTuts { get; set; } = false;
 
         [Description("Extending Command use for Getting a player (such as candy command and other parts of AdminTools). View the README on github for more info.")]

--- a/AdminTools/EventHandlers.cs
+++ b/AdminTools/EventHandlers.cs
@@ -29,7 +29,8 @@ namespace AdminTools
 			Handlers.Server.RoundStarted += OnRoundStarted;
 			Handlers.Player.Destroying += OnPlayerDestroying;
 			Handlers.Player.InteractingDoor += OnPlayerInteractingDoor;
-			Handlers.Player.ChangingRole += OnChangingRole;
+			if (plugin.Config.GodTuts)
+				Handlers.Player.ChangingRole += OnChangingRole;
 		}
 
 		~EventHandlers()
@@ -43,7 +44,8 @@ namespace AdminTools
 			Handlers.Server.RoundStarted -= OnRoundStarted;
 			Handlers.Player.Destroying -= OnPlayerDestroying;
 			Handlers.Player.InteractingDoor -= OnPlayerInteractingDoor;
-			Handlers.Player.ChangingRole -= OnChangingRole;
+			if (plugin.Config.GodTuts)
+				Handlers.Player.ChangingRole -= OnChangingRole;
 		}
 
 		public void OnInteractingDoor(InteractingDoorEventArgs ev)

--- a/AdminTools/EventHandlers.cs
+++ b/AdminTools/EventHandlers.cs
@@ -11,6 +11,7 @@ namespace AdminTools
     using Log = Exiled.API.Features.Log;
     using PlayerStatsSystem;
     using Handlers = Exiled.Events.Handlers;
+    using Exiled.API.Enums;
 
     public class EventHandlers
 	{
@@ -28,9 +29,7 @@ namespace AdminTools
 			Handlers.Server.RoundStarted += OnRoundStarted;
 			Handlers.Player.Destroying += OnPlayerDestroying;
 			Handlers.Player.InteractingDoor += OnPlayerInteractingDoor;
-			
-			if (plugin.Config.GodTuts)
-				Handlers.Player.ChangingRole += OnChangingRole;
+			Handlers.Player.ChangingRole += OnChangingRole;
 		}
 
 		~EventHandlers()
@@ -44,6 +43,7 @@ namespace AdminTools
 			Handlers.Server.RoundStarted -= OnRoundStarted;
 			Handlers.Player.Destroying -= OnPlayerDestroying;
 			Handlers.Player.InteractingDoor -= OnPlayerInteractingDoor;
+			Handlers.Player.ChangingRole -= OnChangingRole;
 		}
 
 		public void OnInteractingDoor(InteractingDoorEventArgs ev)
@@ -127,7 +127,12 @@ namespace AdminTools
 				ev.IsAllowed = false;
 		}
 
-		public void OnChangingRole(ChangingRoleEventArgs ev) => ev.Player.IsGodModeEnabled = ev.NewRole is RoleTypeId.Tutorial;
+		public void OnChangingRole(ChangingRoleEventArgs ev)
+		{
+			if (plugin.Config.GodTuts && ev.Player.RemoteAdminAccess && ev.Reason == SpawnReason.ForceClass)
+				ev.Player.IsGodModeEnabled = ev.NewRole == RoleTypeId.Tutorial;
+		}
+
 
         public void OnWaitingForPlayers()
 		{


### PR DESCRIPTION
Change GodTuts to only God Tuts if they were spawned via command and also have RA permissions, to allow Tutorial to be used as a custom role, while also maintaining the ability for staff to be auto-God'ed