### PR TITLE
Changes GodTuts

### DIFF
--- a/AdminTools/Config.cs
+++ b/AdminTools/Config.cs
@@ -11,7 +11,7 @@ namespace AdminTools
         [Description("Whether or not to show logs used for debugging.")]
         public bool Debug { get; set; } = false;
 
-        [Description("Should Staff be in God Mode when they forceclass to Tutorial?? Default: false")]
+        [Description("Should Tutorials be in God Mode when Forceclassed? Default: false")]
         public bool GodTuts { get; set; } = false;
 
         [Description("Extending Command use for Getting a player (such as candy command and other parts of AdminTools). View the README on github for more info.")]

--- a/AdminTools/EventHandlers.cs
+++ b/AdminTools/EventHandlers.cs
@@ -131,7 +131,7 @@ namespace AdminTools
 
 		public void OnChangingRole(ChangingRoleEventArgs ev)
 		{
-			if (plugin.Config.GodTuts && (ev.Reason == SpawnReason.ForceClass || ev.Reason == SpawnReason.None))
+			if (plugin.Config.GodTuts && (ev.Reason is SpawnReason.ForceClass or SpawnReason.None))
 				ev.Player.IsGodModeEnabled = ev.NewRole == RoleTypeId.Tutorial;
 		}
 

--- a/AdminTools/EventHandlers.cs
+++ b/AdminTools/EventHandlers.cs
@@ -131,7 +131,7 @@ namespace AdminTools
 
 		public void OnChangingRole(ChangingRoleEventArgs ev)
 		{
-			if (plugin.Config.GodTuts && ev.Player.RemoteAdminAccess && ev.Reason == SpawnReason.ForceClass)
+			if (plugin.Config.GodTuts && (ev.Reason == SpawnReason.ForceClass || ev.Reason == SpawnReason.None))
 				ev.Player.IsGodModeEnabled = ev.NewRole == RoleTypeId.Tutorial;
 		}
 


### PR DESCRIPTION
 to apply to anybody who is forceclassed/ spawned with no reason. Allows Jailed individuals to stay in GodMode without affecting the greater Tutorial role (assuming plugins are configured to send the correct RoleChangeReasons, which they should because thats correct thing to do in my opinion don't @ me)